### PR TITLE
expose manifest server with grpc plugin

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -3,8 +3,9 @@ package main
 import (
 	"log"
 
-	coprocess "github.com/TykTechnologies/tyk-protobuf/bindings/go"
 	"golang.org/x/net/context"
+
+	"github.com/TykTechnologies/tyk-protobuf/bindings/go"
 )
 
 // Dispatcher implementation

--- a/hooks.go
+++ b/hooks.go
@@ -11,6 +11,7 @@ func MyPreHook(object *coprocess.Object) (*coprocess.Object, error) {
 	object.Request.SetHeaders = map[string]string{
 		"Myheader": "Myvalue",
 	}
+
 	return object, nil
 }
 
@@ -33,10 +34,10 @@ func MyAuthCheck(object *coprocess.Object) (*coprocess.Object, error) {
 		Rate: 1000.0,
 		Per:  1.0,
 	}
+
 	object.Metadata = map[string]string{
 		"token": validKey,
 	}
 
 	return object, nil
-
 }


### PR DESCRIPTION
Previous implementation requires bundle.zip to be hosted on a webserver somewhere.
This version allows a locally hosted webserver to host bundle.zip for convenience.
