### PR TITLE
fix: gateway warning incorrect key expiry

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -37,6 +37,8 @@ func MyAuthCheck(object *coprocess.Object) (*coprocess.Object, error) {
 	object.Session = &coprocess.SessionState{
 		Rate:                1000.0,
 		Per:                 1.0,
+		QuotaMax:            int64(1000),
+		QuotaRenews:         time.Now().Unix(),
 		IdExtractorDeadline: extractorDeadline,
 	}
 

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 		log.Fatalf("Failed to listen: %v", err)
 	}
 
-	log.Println("Listening...", ListenAddress)
+	log.Printf("starting grpc server on %v", ListenAddress)
 	s := grpc.NewServer()
 	coprocess.RegisterDispatcherServer(s, &Dispatcher{})
 	go s.Serve(lis)
@@ -31,5 +31,6 @@ func main() {
 		http.ServeFile(w, r, "bundle.zip")
 	})
 
-	http.ListenAndServe(ManifestAddress, nil)
+	log.Printf("starting bundle manifest server on %v", ManifestAddress)
+	log.Fatal(http.ListenAndServe(ManifestAddress, nil))
 }


### PR DESCRIPTION
Because we do not set QuotaMax & QuotaRenews, when API key is used, the
gateway spits out a warning `WARN Incorrect key expiry setting detected,
correcting`.
    
This fix simply includes these fields inside the session object to
suppress the warning error.
